### PR TITLE
Send requests individually

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,12 @@
         "title": "Variables"
       },
       {
+        "command": "postman-collection-explorer.sendRequest",
+        "title": "Send Request",
+        "category": "Postman",
+        "icon": "$(export)"
+      },
+      {
         "command": "postman-collection-explorer.viewApiDescription",
         "title": "View API Description",
         "category": "Postman"
@@ -208,6 +214,10 @@
         {
           "command": "postman-collection-explorer.editVariables",
           "when": "false"
+        },
+        {
+          "command": "postman-collection-explorer.sendRequest",
+          "when": "false"
         }
       ],
       "view/item/context": [
@@ -225,6 +235,11 @@
           "command": "postman-collection-explorer.remove",
           "when": "view == postmanCollectionExplorer",
           "group": "inline@3"
+        },
+        {
+          "command": "postman-collection-explorer.sendRequest",
+          "when": "view == postmanCollectionExplorer && viewItem == request",
+          "group": "inline@4"
         },
         {
           "command": "postman-collection-explorer.rename",

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -17,6 +17,7 @@ import { editUrl } from './requests/editUrl';
 import { editHeaders } from './requests/editHeaders';
 import { editParameters } from './requests/editParameters';
 import { editVariables } from './collections/editVariables';
+import { sendRequest } from './requests/sendRequest';
 
 export const EXTENSION_PREFIX = 'postman-collection-explorer';
 
@@ -38,6 +39,7 @@ export const commands = {
   remove,
   rename,
   viewApiDescription,
+  sendRequest,
   runTests,
   getContext: (): vscode.ExtensionContext => ({} as vscode.ExtensionContext)
 };

--- a/src/commands/requests/sendRequest.ts
+++ b/src/commands/requests/sendRequest.ts
@@ -1,0 +1,46 @@
+import { window, workspace } from 'vscode';
+import { RunExecutionResponse } from '../../postman';
+import { getCollection, runWithNewman } from '../../utils';
+import { PostmanItemModel } from '../../views/postmanItems/postmanItemModel';
+
+export async function sendRequest(item?: PostmanItemModel): Promise<void> {
+  if (item === undefined || !item.isRequest()) {
+    return;
+  }
+
+  const request = item.itemObject;
+  const summary = await runWithNewman({ collection: getCollection(request).rootItem, folder: request.id });
+  if (summary[0] !== null || summary[1] === undefined) {
+    console.warn(`Could not run request ${request.name}\n`, summary[0]);
+    return;
+  }
+
+  const executions = summary[1].run.executions;
+  if (executions.length === 0) {
+    return;
+  }
+
+  let response:  RunExecutionResponse | undefined = executions[0].response;
+  if (executions.length > 1) {
+    const execution = executions.find((e) => e.item.name === request.name);
+    response = execution?.response;
+  }
+
+  if (response === undefined) {
+    return;
+  }
+
+  const orderedResponse = {
+    code: response.code,
+    status: response.status,
+    responseTimeInMs: response.responseTime,
+    responseSizeInB: response.responseSize,
+    cookies: response.cookie,
+    headers: response.header,
+    body: Buffer.from(response.stream.data).toString()
+  };
+
+  const document = await workspace.openTextDocument({ language: 'json', content: JSON.stringify(orderedResponse, undefined, 2) });
+
+  await window.showTextDocument(document);
+}

--- a/src/postman/newmanTypes.ts
+++ b/src/postman/newmanTypes.ts
@@ -75,6 +75,7 @@ export interface Run {
 export interface RunExecution {
   item: RunExecutionItem;
   assertions?: RunExecutionAssertion[];
+  response: RunExecutionResponse;
 }
 
 export interface RunExecutionItem {
@@ -86,4 +87,15 @@ export interface RunExecutionAssertion {
   assertion: string;
   skipped: boolean;
   error?: NewmanRunExecutionAssertionError;
+}
+
+export interface RunExecutionResponse {
+  code: number;
+  cookie: any[];
+  header: any[];
+  id: string;
+  responseSize: number;
+  responseTime: number;
+  status: string;
+  stream: { type: string; data: number[] };
 }


### PR DESCRIPTION
Information about how you resolved the issue: Used `runNewman` with folder argument set to the id of the request to only run one request. Every returned execution gets displayed in a virtual json document after the requests have been run.